### PR TITLE
Thread ui realign

### DIFF
--- a/src/renderer/components/content-types/ThreadContent.css
+++ b/src/renderer/components/content-types/ThreadContent.css
@@ -18,14 +18,13 @@
 }
 
 .messageGroup {
-  margin-bottom: -24px;
   padding-top: 12px;
+  display: flex;
+  align-items: flex-start;
 }
 
 .groupedMessages {
-  position: relative;
-  top: -20px;
-  padding-left: 48px;
+  padding-left: 32px;
 }
 
 .messages {
@@ -47,7 +46,6 @@
 }
 
 .username {
-  padding-left: 8px;
   font-size: 12px;
   color: var(--colorBlueBlack);
 }

--- a/src/renderer/components/content-types/ThreadContent.tsx
+++ b/src/renderer/components/content-types/ThreadContent.tsx
@@ -24,9 +24,9 @@ interface Doc {
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   localeMatcher: 'best fit',
   weekday: 'short',
-  hour: '2-digit',
+  hour: 'numeric',
   minute: '2-digit',
-  month: 'short',
+  month: 'numeric',
   day: 'numeric',
 })
 

--- a/src/renderer/components/content-types/contact/ContactInVarious.css
+++ b/src/renderer/components/content-types/contact/ContactInVarious.css
@@ -15,10 +15,12 @@
 
 .Contact-user {
   display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: min-content;
 }
 
 .Contact-username {
-  padding-left: 8px;
   font-size: 12px;
   color: var(--colorBlueBlack);
 }


### PR DESCRIPTION
I changed how layout for the message metadata (author, avatar, date) so that it wouldn't overlap when the thread gets to narrow. Also made positioning less rigid— not sure if flexbox was intentionally avoided or if it's cool to use.