### PR TITLE
only apply padding to text cards

### DIFF
--- a/src/renderer/components/content-types/TextContent.css
+++ b/src/renderer/components/content-types/TextContent.css
@@ -27,6 +27,7 @@
   min-height: 100%;
   cursor: text;
   overflow: hidden;
+  padding: var(--halfCellSize);
 }
 
 .ql-clipboard {

--- a/src/renderer/components/content-types/board/BoardCard.css
+++ b/src/renderer/components/content-types/board/BoardCard.css
@@ -20,7 +20,6 @@
   box-sizing: border-box;
   overflow: hidden;
   border: solid 1px var(--colorPaleGrey);
-  padding: var(--halfCellSize);
 }
 
 .BoardCard:focus,


### PR DESCRIPTION
Media content should be able to fill entire card, not have the same left-right padding as text 