### PR TITLE
change resize cursor style to nwse

### DIFF
--- a/src/renderer/components/content-types/board/BoardCard.css
+++ b/src/renderer/components/content-types/board/BoardCard.css
@@ -47,7 +47,7 @@
   background-position: bottom right;
   background-repeat: no-repeat;
   background-origin: content-box;
-  cursor: se-resize;
+  cursor: nwse-resize;
   visibility: hidden;
 
   /* Card content might use z-index as well so use high


### PR DESCRIPTION
Tiny fix but the cursor should probably have arrows pointing both ways for resizing cards, since resizing goes both ways.

P.S. Would you rather these kinds of small fixes bundled in one PR in the future?