### PR TITLE
rm webkit audio background + width constraints

### DIFF
--- a/src/renderer/components/content-types/files/AudioContent.css
+++ b/src/renderer/components/content-types/files/AudioContent.css
@@ -1,0 +1,7 @@
+audio {
+  flex: 1;
+  outline: none;
+}
+audio::-webkit-media-controls-panel {
+  background-color: white;
+}


### PR DESCRIPTION
removes an ugly grey pill background from audio cards

couldn't figure out how to style download dialog (not in any webkit documentation that I could find), so pressing the three dots on the right side still opens a download dialog that is out of view of the card