### PR TITLE
docs: update *some* site links, inkandswitch -> automerge

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -8,7 +8,7 @@ You can make PushPin into almost anything by replacing the right pieces. You cou
 
 Before you begin, you're going to need to install PushPin on your computer.
 
-Go to [github.com/inkandswitch/pushpin](https://github.com/inkandswitch/pushpin) and check out the repository there.
+Go to [github.com/automerge/pushpin](https://github.com/automerge/pushpin) and check out the repository there.
 
 From the checked-out copy, run the following commands:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,8 +9,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta property="og:title" content="PushPin" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://inkandswitch.github.io/pushpin/" />
-    <meta property="og:image" content="https://inkandswitch.github.io/pushpin/pushpin-logo.png" />
+    <meta property="og:url" content="https://automerge.github.io/pushpin/" />
+    <meta property="og:image" content="https://automerge.github.io/pushpin/pushpin-logo.png" />
     <meta
       property="og:description"
       content="PushPin is a collaborative digital workspace that works offline and syncs in realtime, based on Hypercore and Automerge technologies"
@@ -35,7 +35,7 @@
             <div class="ImageBadge ImageBadge--dark"><img src="iconMac.c000c463.svg" /></div>
             <a
               class="Button"
-              href="https://github.com/inkandswitch/pushpin/releases/download/2.0.0-beta2/PushPin-2.0.0-beta2.dmg"
+              href="https://github.com/automerge/pushpin/releases/download/2.0.0-beta2/PushPin-2.0.0-beta2.dmg"
               >MacOS Download</a
             >
           </div>
@@ -43,13 +43,13 @@
             <div class="ImageBadge ImageBadge--blue"><img src="iconWindows.798f62e9.svg" /></div>
             <a
               class="Button"
-              href="https://github.com/inkandswitch/pushpin/releases/download/2.0.0-beta2/PushPin.Setup.2.0.0-beta2.exe"
+              href="https://github.com/automerge/pushpin/releases/download/2.0.0-beta2/PushPin.Setup.2.0.0-beta2.exe"
               >Windows Download</a
             >
           </div>
           <div class="Download__options__option">
             <div class="ImageBadge ImageBadge--green"><img src="iconGithub.179812a7.svg" /></div>
-            <a class="Button" href="https://github.com/inkandswitch/pushpin">View on GitHub</a>
+            <a class="Button" href="https://github.com/automerge/pushpin">View on GitHub</a>
           </div>
         </div>
       </div>
@@ -193,7 +193,7 @@
         <p class="Type--secondary">
           PushPin is an <a href="https://inkandswitch.com/">Ink & Switch project</a>. PushPin is
           distributed under a
-          <a href="https://github.com/inkandswitch/pushpin/blob/master/LICENSE" title="View license"
+          <a href="https://github.com/automerge/pushpin/blob/master/LICENSE" title="View license"
             >BSD 3-Clause "New" or "Revised" License</a
           >
           and is provided without warranty.


### PR DESCRIPTION
closes https://github.com/automerge/pushpin/issues/382

there are still references to inkandswitch, such as the package author,
but I don't feel it's not my place to update this. intent is just to fix the website
links. 😊